### PR TITLE
refactor(rakmaty-survey): never use await in a loop, add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line=lf
+indent_style=tab

--- a/commands/fun/rakmaty-survey.js
+++ b/commands/fun/rakmaty-survey.js
@@ -43,7 +43,8 @@ export default {
 				})
 			];
 
-			return (await Promise.allSettled(promises)).flat();
+			return (await Promise.allSettled(promises))
+				.filter(res => res.status === 'fulfilled').flatMap(res => res.value);
 		}).filter(Boolean))
 
 

--- a/commands/fun/rakmaty-survey.js
+++ b/commands/fun/rakmaty-survey.js
@@ -22,65 +22,45 @@ export default {
 		const guilds = await interaction.client.guilds.fetch();
 
 		let times = [];
-		let countAll = 0, countRakmaty = 0;
 
-		for (const [guildPartialId, guildPartial] of guilds) {
+		const channels = await Promise.all(guilds.map(async (guildPartial) => {
 			const guild = await guildPartial.fetch();
-			const channels = await guild.channels.fetch();
+			return await guild.channels.fetch();
+		}));
 
-			for (const [channelId, channel] of channels) {
-				if (!channel.threads) continue;
+		const threads = await Promise.all(channels.map(async (channel) => {
+			if (!channel.threads) return null
 
-				const threadsFetchedActive = await channel.threads.fetchActive();
+			const promises = [
+				channel.threads.fetchActive(),
+				channel.threads.fetchArchived({
+					type: 'public',
+					fetchAll: true,
+				}),
+				channel.threads.fetchArchived({
+					type: 'private',
+					fetchAll: true,
+				})
+			];
+
+			return (await Promise.allSettled(promises)).flat();
+		}).filter(Boolean))
 
 
-				let threadsFetchedArchivedPublic, threadsFetchedArchivedPrivate;
+		const countAll = threads.length;
+		const countRakmaty = await Promise.all(threads.map(async (thread) => {
+			try {
+				const rakmaty = await thread.members.fetch(process.env.RAKMATY_ID);
 
-				try {
-					threadsFetchedArchivedPublic = await channel.threads.fetchArchived({
-						type: 'public',
-						fetchAll: true,
-					});
-				}
-				// eslint-disable-next-line no-empty
-				catch {}
+				const seconds = Math.floor((rakmaty.joinedTimestamp - (Number(BigInt.asUintN(64, thread.id) >> 22n) + 1420070400000)) / 1000);
 
-				try {
-					threadsFetchedArchivedPrivate = await channel.threads.fetchArchived({
-						type: 'private',
-						fetchAll: true,
-					});
-				}
-				// eslint-disable-next-line no-empty
-				catch {}
+				if (thread.ownerId != process.env.RAKMATY_ID && seconds > 1) times.push(seconds);
 
-				let threads = threadsFetchedActive.threads;
-
-				if (threadsFetchedArchivedPublic) threads = threads.concat(threadsFetchedArchivedPublic.threads);
-				if (threadsFetchedArchivedPrivate) threads = threads.concat(threadsFetchedArchivedPrivate.threads);
-
-				if (threads.size === 0) continue;
-
-				for (const [threadId, thread ] of threads) {
-					countAll++;
-					if (countAll % 30 == 0 && countAll != 0) await interaction.editReply(`⏩ prošel jsem už ${countAll} threadů, v ${countRakmaty} z nich byl rakmaty, hledám dál...`);
-
-					let rakmaty1;
-					try {
-						rakmaty1 = await thread.members.fetch(process.env.RAKMATY_ID);
-					}
-					catch {
-						continue;
-					}
-
-					countRakmaty++;
-
-					const seconds = Math.floor((rakmaty1.joinedTimestamp - (Number(BigInt.asUintN(64, thread.id) >> 22n) + 1420070400000)) / 1000);
-
-					if (thread.ownerId != process.env.RAKMATY_ID && seconds > 1) times.push(seconds);
-				}
+				return true;
+			} catch {
+				return false;
 			}
-		}
+		})).filter(Boolean).length;
 
 		if (countRakmaty === 0) throw new Error(`peepo: v žádném z threadů do kterých mám přístup (celkem ${countAll}) není rakmaty`);
 		if (times.length === 0) throw new Error(`peepo: prošel jsem všechny thready do kterých mám přístup (celkem ${countAll}) a je v nich rakmaty (celkem ${countRakmaty}), ale žádný nevyhovuje podmínkám pro statistiky (thready založené rakmatym se nepočítají, stejně tak thready do kterých byl přidaný první zprávou).`);

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "main": "index.js",
-  "type": "module",
-  "scripts": {
-    "start": "node .",
-    "dev": "nodemon --delay 5.0 index.js"
-  },
-  "dependencies": {
-    "discord.js": "^14.21.0",
-    "dotenv": "^17.0.1",
-    "mysql2": "^3.14.1",
-    "node-cache": "^5.1.2",
-    "node-cron": "^4.2.0",
-    "node-fetch": "^3.3.2",
-    "sequelize": "^6.37.7",
-    "uuid": "^11.1.0"
-  },
-  "devDependencies": {
-    "eslint": "^9.30.1",
-    "nodemon": "^3.1.10"
-  }
+	"main": "index.js",
+	"type": "module",
+	"scripts": {
+		"start": "node .",
+		"dev": "nodemon --delay 5.0 index.js"
+	},
+	"dependencies": {
+		"discord.js": "^14.21.0",
+		"dotenv": "^17.0.1",
+		"mysql2": "^3.14.1",
+		"node-cache": "^5.1.2",
+		"node-cron": "^4.2.0",
+		"node-fetch": "^3.3.2",
+		"sequelize": "^6.37.7",
+		"uuid": "^11.1.0"
+	},
+	"devDependencies": {
+		"eslint": "^9.30.1",
+		"nodemon": "^3.1.10"
+	}
 }


### PR DESCRIPTION
When using await inside a loop, each iteration has to wait till the previous one is finished - each request is blocking the whole computation. I refactored the code to be less nested and to use the Promise utilities and Array prototype functions

`Promise.all([promise1, promise2])` - starts all promises at the same time, waits till all are done or till one rejects (error is thrown)
`Promise.allSettled[promise1, promise2])` - starts all promises at the same time, waits till all are done, doesnt fail if promise rejects

`[1, 2, 3, 4].filter(num => num > 2)` filters elements based on supplied predicate (returns new array with elements that satisfy said predicate)
`[true, false, undefined, null, true].filter(Boolean)` filters based on whether value is truthy / falsy - boolean constructor is used as a predicate
`[[1, 2], [3, 4]].flat()` flattens nested arrays into a single array (isnt recursive) - returns `[1, 2, 3, 4]`